### PR TITLE
run: added a start-on-toolforge entry

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node server.js
+web: npm run start-on-toolforge

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "node server.js",
+    "start-on-toolforge": "node .next/standalone/server.js",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
Both in the procfile and in package.json, as the path for the server is in a different place when running on toolforge.